### PR TITLE
Add registration form and controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ writable/uploads/*
 
 writable/debugbar/*
 !writable/debugbar/.gitkeep
+writable/*.sqlite
 
 php_errors.log
 

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -6,3 +6,4 @@ use CodeIgniter\Router\RouteCollection;
  * @var RouteCollection $routes
  */
 $routes->get('/', 'Home::index');
+$routes->match(['get', 'post'], 'register', 'AuthController::register');

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Models\UserModel;
+use CodeIgniter\Controller;
+
+class AuthController extends BaseController
+{
+    protected UserModel $users;
+
+    public function __construct()
+    {
+        $this->users = new UserModel();
+        helper(['form']);
+    }
+
+    public function register()
+    {
+        if ($this->request->getMethod() === 'post') {
+            $data = [
+                'username' => $this->request->getPost('username'),
+                'email'    => $this->request->getPost('email'),
+                'password' => $this->request->getPost('password'),
+                'role_id'  => $this->request->getPost('role_id'),
+            ];
+
+            if (!$this->users->validate($data)) {
+                return view('auth/register', [
+                    'validation' => $this->users->validator,
+                    'roles'      => $this->getRoles(),
+                ]);
+            }
+
+            $this->users->createUser($data);
+
+            return redirect()->to('/');
+        }
+
+        return view('auth/register', [
+            'roles' => $this->getRoles(),
+        ]);
+    }
+
+    private function getRoles(): array
+    {
+        $db = \Config\Database::connect();
+
+        return $db->table('roles')->select('id, name')->get()->getResultArray();
+    }
+}

--- a/app/Database/Migrations/2025-07-18-072535_CreateRolesTable.php
+++ b/app/Database/Migrations/2025-07-18-072535_CreateRolesTable.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateRolesTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id'         => [
+                'type'           => 'INT',
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+            'name'       => [
+                'type'       => 'VARCHAR',
+                'constraint' => 50,
+            ],
+            'created_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'updated_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('roles');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('roles');
+    }
+}

--- a/app/Database/Migrations/2025-07-18-072537_CreateUsersTable.php
+++ b/app/Database/Migrations/2025-07-18-072537_CreateUsersTable.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreateUsersTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id'            => [
+                'type'           => 'INT',
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+            'username'      => [
+                'type'       => 'VARCHAR',
+                'constraint' => 100,
+            ],
+            'email'         => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+            ],
+            'password_hash' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 255,
+            ],
+            'role_id'       => [
+                'type'     => 'INT',
+                'unsigned' => true,
+            ],
+            'created_at'    => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'updated_at'    => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'deleted_at'    => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->addForeignKey('role_id', 'roles', 'id', 'CASCADE', 'CASCADE');
+        $this->forge->createTable('users');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('users');
+    }
+}

--- a/app/Database/Migrations/2025-07-18-072538_CreatePasswordResetTokensTable.php
+++ b/app/Database/Migrations/2025-07-18-072538_CreatePasswordResetTokensTable.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class CreatePasswordResetTokensTable extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id'         => [
+                'type'           => 'INT',
+                'unsigned'       => true,
+                'auto_increment' => true,
+            ],
+            'user_id'    => [
+                'type'     => 'INT',
+                'unsigned' => true,
+            ],
+            'token'      => [
+                'type'       => 'VARCHAR',
+                'constraint' => 64,
+            ],
+            'expires_at' => [
+                'type' => 'DATETIME',
+            ],
+            'created_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'updated_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+
+        $this->forge->addKey('id', true);
+        $this->forge->addForeignKey('user_id', 'users', 'id', 'CASCADE', 'CASCADE');
+        $this->forge->createTable('password_reset_tokens');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('password_reset_tokens');
+    }
+}

--- a/app/Models/UserModel.php
+++ b/app/Models/UserModel.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class UserModel extends Model
+{
+    protected $table      = 'users';
+    protected $primaryKey = 'id';
+    protected $returnType = 'array';
+    protected $useSoftDeletes = true;
+    protected $allowedFields = [
+        'username',
+        'email',
+        'password_hash',
+        'role_id',
+    ];
+    protected $useTimestamps = true;
+
+    protected $validationRules = [
+        'username' => 'required|min_length[3]|max_length[100]',
+        'email'    => 'required|valid_email|max_length[255]',
+        'password' => 'permit_empty|min_length[8]',
+        'role_id'  => 'required|is_natural_no_zero',
+    ];
+
+    public function createUser(array $data): int
+    {
+        if (isset($data['password'])) {
+            $data['password_hash'] = password_hash($data['password'], PASSWORD_DEFAULT);
+            unset($data['password']);
+        }
+
+        $this->insert($data);
+
+        return $this->getInsertID();
+    }
+
+    public function getUser(int $id): ?array
+    {
+        return $this->select('users.*, roles.name as role_name')
+            ->join('roles', 'roles.id = users.role_id', 'left')
+            ->find($id);
+    }
+
+    public function updateUser(int $id, array $data): bool
+    {
+        if (isset($data['password'])) {
+            $data['password_hash'] = password_hash($data['password'], PASSWORD_DEFAULT);
+            unset($data['password']);
+        }
+
+        return $this->update($id, $data);
+    }
+
+    public function deleteUser(int $id, bool $purge = false): bool
+    {
+        return $this->delete($id, $purge);
+    }
+}

--- a/app/Views/auth/register.php
+++ b/app/Views/auth/register.php
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+</head>
+<body>
+    <h1>Register</h1>
+    <?php if (isset($validation)): ?>
+        <div class="errors">
+            <?= $validation->listErrors() ?>
+        </div>
+    <?php endif; ?>
+    <form action="" method="post">
+        <?= csrf_field() ?>
+        <div>
+            <label for="username">Name</label>
+            <input type="text" name="username" id="username" value="<?= old('username') ?>">
+        </div>
+        <div>
+            <label for="email">Email</label>
+            <input type="email" name="email" id="email" value="<?= old('email') ?>">
+        </div>
+        <div>
+            <label for="password">Password</label>
+            <input type="password" name="password" id="password">
+        </div>
+        <div>
+            <label for="role_id">Role</label>
+            <select name="role_id" id="role_id">
+                <?php foreach ($roles as $role): ?>
+                    <option value="<?= $role['id'] ?>" <?= set_select('role_id', $role['id']) ?>>
+                        <?= esc($role['name']) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <button type="submit">Register</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `AuthController::register` with validation and user creation
- add registration form view with CSRF and role dropdown
- wire up new route for `/register`

## Testing
- `php -l app/Controllers/AuthController.php`
- `php -l app/Views/auth/register.php`
- `php -l app/Config/Routes.php`
- `php spark migrate --all --pretend` *(fails: vendor directory missing)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6879f4347c30832caa9ae84501768ee6