### PR TITLE
Implement login and logout

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -7,3 +7,5 @@ use CodeIgniter\Router\RouteCollection;
  */
 $routes->get('/', 'Home::index');
 $routes->match(['get', 'post'], 'register', 'AuthController::register');
+$routes->match(['get', 'post'], 'login', 'AuthController::login');
+$routes->get('logout', 'AuthController::logout');

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -42,6 +42,41 @@ class AuthController extends BaseController
         ]);
     }
 
+    public function login()
+    {
+        if ($this->request->getMethod() === 'post') {
+            $email    = $this->request->getPost('email');
+            $password = $this->request->getPost('password');
+
+            $user = $this->users->where('email', $email)->first();
+
+            if ($user && password_verify($password, $user['password_hash'])) {
+                $session = session();
+                $session->set([
+                    'user_id'   => $user['id'],
+                    'username'  => $user['username'],
+                    'logged_in' => true,
+                ]);
+
+                return redirect()->to('/');
+            }
+
+            return redirect()->back()
+                ->with('error', 'Invalid email or password.')
+                ->withInput();
+        }
+
+        return view('auth/login');
+    }
+
+    public function logout()
+    {
+        $session = session();
+        $session->destroy();
+
+        return redirect()->to('/');
+    }
+
     private function getRoles(): array
     {
         $db = \Config\Database::connect();

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <?php if (session()->getFlashdata('error')): ?>
+        <div class="errors">
+            <?= session()->getFlashdata('error') ?>
+        </div>
+    <?php endif; ?>
+    <form action="" method="post">
+        <?= csrf_field() ?>
+        <div>
+            <label for="email">Email</label>
+            <input type="email" name="email" id="email" value="<?= old('email') ?>">
+        </div>
+        <div>
+            <label for="password">Password</label>
+            <input type="password" name="password" id="password">
+        </div>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `login` and `logout` endpoints
- implement login form
- initialize session on login success

## Testing
- `composer install`
- `php -l app/Controllers/AuthController.php`
- `php -l app/Views/auth/login.php`
- `php -l app/Config/Routes.php`


------
https://chatgpt.com/codex/tasks/task_b_6879fc8a28b4832caaddb05dc1002a9d