### PR TITLE
Enable sessions and CSRF protection

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -70,7 +70,7 @@ class Filters extends BaseFilters
     public array $globals = [
         'before' => [
             // 'honeypot',
-            // 'csrf',
+            'csrf',
             // 'invalidchars',
         ],
         'after' => [

--- a/app/Config/Security.php
+++ b/app/Config/Security.php
@@ -15,7 +15,7 @@ class Security extends BaseConfig
      *
      * @var string 'cookie' or 'session'
      */
-    public string $csrfProtection = 'cookie';
+    public string $csrfProtection = 'session';
 
     /**
      * --------------------------------------------------------------------------

--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -7,6 +7,7 @@ use CodeIgniter\HTTP\CLIRequest;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
+use CodeIgniter\Session\Session;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -41,7 +42,12 @@ abstract class BaseController extends Controller
      * Be sure to declare properties for any property fetch you initialized.
      * The creation of dynamic property is deprecated in PHP 8.2.
      */
-    // protected $session;
+    /**
+     * Session instance
+     *
+     * @var Session
+     */
+    protected $session;
 
     /**
      * @return void
@@ -53,6 +59,6 @@ abstract class BaseController extends Controller
 
         // Preload any models, libraries, etc, here.
 
-        // E.g.: $this->session = service('session');
+        $this->session = service('session');
     }
 }


### PR DESCRIPTION
## Summary
- initialize the CodeIgniter session service in BaseController
- store CSRF tokens in the session
- enable the CSRF filter globally

## Testing
- `php --version`

------
https://chatgpt.com/codex/tasks/task_b_6879fe70486c832c975d5203c939b962