### PR TITLE
Implement password reset flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Hieronder staan 10 mogelijke functionaliteiten voor de CodeIgniter-applicatie, e
 1. Gebruikerregistratie met rollen (Beheer, Accountmanager, Klant)
 2. Inloggen/uitloggen
 3. Wachtwoord reset via e-mail
+   - Formulier voor vergeten wachtwoord op `/forgot-password`
+   - Resetlink per e-mail met tijdelijk token
 4. Tweestapsverificatie
 5. Rolgebaseerde toegangscontrole (per controller/methode)
 6. Gebruikersprofielen met bewerk-/bekijkrechten

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -9,3 +9,5 @@ $routes->get('/', 'Home::index');
 $routes->match(['get', 'post'], 'register', 'AuthController::register');
 $routes->match(['get', 'post'], 'login', 'AuthController::login');
 $routes->get('logout', 'AuthController::logout');
+$routes->match(['get', 'post'], 'forgot-password', 'AuthController::forgotPassword');
+$routes->match(['get', 'post'], 'reset-password', 'AuthController::resetPassword');

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -77,6 +77,73 @@ class AuthController extends BaseController
         return redirect()->to('/');
     }
 
+    public function forgotPassword()
+    {
+        if ($this->request->getMethod() === 'post') {
+            $email = $this->request->getPost('email');
+            $user  = $this->users->where('email', $email)->first();
+
+            if ($user) {
+                $token      = bin2hex(random_bytes(32));
+                $expires_at = date('Y-m-d H:i:s', time() + 3600);
+
+                $resetModel = new \App\Models\PasswordResetTokenModel();
+                $resetModel->insert([
+                    'user_id'    => $user['id'],
+                    'token'      => $token,
+                    'expires_at' => $expires_at,
+                ]);
+
+                $emailService = service('email');
+                $emailService->setTo($user['email']);
+                $emailService->setSubject('Password Reset');
+                $link = base_url('reset-password?token=' . $token);
+                $emailService->setMessage(
+                    "Click the link to reset your password: {$link}"
+                );
+                $emailService->send();
+            }
+
+            return redirect()->to('login')
+                ->with('message', 'If the email exists, a reset link has been sent.');
+        }
+
+        return view('auth/forgot_password');
+    }
+
+    public function resetPassword()
+    {
+        $token = $this->request->getGet('token');
+        $resetModel = new \App\Models\PasswordResetTokenModel();
+
+        $record = $resetModel
+            ->where('token', $token)
+            ->where('expires_at >=', date('Y-m-d H:i:s'))
+            ->first();
+
+        if (!$record) {
+            return redirect()->to('login')->with('error', 'Invalid or expired token.');
+        }
+
+        if ($this->request->getMethod() === 'post') {
+            $password = $this->request->getPost('password');
+
+            if (strlen($password) < 8) {
+                return view('auth/reset_password', [
+                    'token' => $token,
+                    'error' => 'Password must be at least 8 characters.',
+                ]);
+            }
+
+            $this->users->updateUser($record['user_id'], ['password' => $password]);
+            $resetModel->delete($record['id']);
+
+            return redirect()->to('login')->with('message', 'Password reset successful.');
+        }
+
+        return view('auth/reset_password', ['token' => $token]);
+    }
+
     private function getRoles(): array
     {
         $db = \Config\Database::connect();

--- a/app/Models/PasswordResetTokenModel.php
+++ b/app/Models/PasswordResetTokenModel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class PasswordResetTokenModel extends Model
+{
+    protected $table      = 'password_reset_tokens';
+    protected $primaryKey = 'id';
+
+    protected $allowedFields = [
+        'user_id',
+        'token',
+        'expires_at',
+    ];
+
+    protected $useTimestamps = true;
+    protected $returnType    = 'array';
+}

--- a/app/Views/auth/forgot_password.php
+++ b/app/Views/auth/forgot_password.php
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Forgot Password</title>
+</head>
+<body>
+    <h1>Forgot Password</h1>
+    <form action="" method="post">
+        <?= csrf_field() ?>
+        <div>
+            <label for="email">Email</label>
+            <input type="email" name="email" id="email" required>
+        </div>
+        <button type="submit">Send Reset Link</button>
+    </form>
+</body>
+</html>

--- a/app/Views/auth/reset_password.php
+++ b/app/Views/auth/reset_password.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Reset Password</title>
+</head>
+<body>
+    <h1>Reset Password</h1>
+    <?php if (isset($error)): ?>
+        <div class="errors">
+            <?= esc($error) ?>
+        </div>
+    <?php endif; ?>
+    <form action="?token=<?= urlencode($token) ?>" method="post">
+        <?= csrf_field() ?>
+        <div>
+            <label for="password">New Password</label>
+            <input type="password" name="password" id="password" required>
+        </div>
+        <button type="submit">Update Password</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add docs for password reset routes
- register password reset routes
- implement token creation and validation in `AuthController`
- store tokens with new `PasswordResetTokenModel`
- add simple views for requesting and setting a new password

## Testing
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6879ff86eefc832c9b07e4857478cefb